### PR TITLE
Fix for incorrect static identifier and incorrect logical expression

### DIFF
--- a/Nachos/nachos/userprog/UserProcess.java
+++ b/Nachos/nachos/userprog/UserProcess.java
@@ -540,9 +540,9 @@ public class UserProcess {
 		if (parentProcess != null) 
 		{
 			//acquire the lock for the parent process
-			lock.acquire(); // LEX please check this
+			parentProcess.lock.acquire(); // LEX please check this
 			parentProcess.childProcessStatus.put(processID, status);
-			lock.release(); // LEX please check this
+			parentProcess.lock.release(); // LEX please check this
 
 		}
 		

--- a/Nachos/nachos/userprog/UserProcess.java
+++ b/Nachos/nachos/userprog/UserProcess.java
@@ -219,7 +219,7 @@ public class UserProcess {
 		//start reading the memory
 		for (int i = Machine.processor().pageFromAddress(vaddr); i <= Machine.processor().pageFromAddress(end); i++) {
 			//break if the address is negative, exceeds the allowed range, empty, or referencing to invalid page
-			if ((i < 0 || i > pageTable.length) || pageTable == null || !pageTable[i].valid)
+			if ((i < 0 || i >= pageTable.length) || pageTable == null || !pageTable[i].valid)
 				break;
 			
 			//store the address of byte currently being referenced

--- a/Nachos/nachos/userprog/UserProcess.java
+++ b/Nachos/nachos/userprog/UserProcess.java
@@ -1171,7 +1171,7 @@ public class UserProcess {
 	//PART 3 VARIABLES
 	protected UserProcess parentProcess; //hold parent process
 	protected LinkedList<UserProcess> childProcesses; //maintain list of child processes
-	private static Lock lock; //lock needed for implementation
+	private Lock lock; //lock needed for implementation
 	protected UThread thread; //thread needed for joining 
 	protected HashMap<Integer, Integer> childProcessStatus; //maintain child status
 	protected static int counter = 0; //needed to make process ID


### PR DESCRIPTION
See #3 and #4 

For #3 : converted `private static Lock lock` to `private Lock lock` [here](https://github.com/ycchang27/NachOS/blob/master/Nachos/nachos/userprog/UserProcess.java#L1174).

For #4 : converted `i > pageTable.length` to `i >= pageTable.length` [here](https://github.com/ycchang27/NachOS/blob/master/Nachos/nachos/userprog/UserProcess.java#L222).